### PR TITLE
Refactor/football/18

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/backend/src/main/java/com/personal/kopmorning/KopmorningApplication.java
+++ b/backend/src/main/java/com/personal/kopmorning/KopmorningApplication.java
@@ -2,6 +2,7 @@ package com.personal.kopmorning;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -9,6 +10,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableWebSecurity
+@EnableCaching
 @EnableScheduling
 public class KopmorningApplication {
 

--- a/backend/src/main/java/com/personal/kopmorning/domain/football/controller/FootBallController.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/football/controller/FootBallController.java
@@ -25,7 +25,7 @@ public class FootBallController {
 
     @PostMapping("/save")
     public RsData<?> save() {
-        footBallService.saveFootBallData();
+        footBallService.saveTeamAndPlayer();
         footBallService.saveStanding();
         footBallService.saveFixtures();
         footBallService.saveTopScorer();

--- a/backend/src/main/java/com/personal/kopmorning/domain/football/controller/FootBallController.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/football/controller/FootBallController.java
@@ -65,8 +65,8 @@ public class FootBallController {
     @GetMapping("/matches")
     public RsData<List<GameResponse>> getMatches() {
         return new RsData<>(
-                "200",
-                "성공",
+                FootBallSuccessCode.GET_GAME_LIST.getCode(),
+                FootBallSuccessCode.GET_GAME_LIST.getMessage(),
                 footBallService.getGameList()
         );
     }
@@ -74,8 +74,8 @@ public class FootBallController {
     @GetMapping("/ranking/{standard}")
     public RsData<List<RankingResponse>> getRanking(@PathVariable String standard) {
         return new RsData<>(
-                "200",
-                "성공",
+                FootBallSuccessCode.GET_RANKING_LIST.getCode(),
+                FootBallSuccessCode.GET_RANKING_LIST.getMessage(),
                 footBallService.getRanking(standard)
         );
     }

--- a/backend/src/main/java/com/personal/kopmorning/domain/football/controller/FootBallController.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/football/controller/FootBallController.java
@@ -9,6 +9,7 @@ import com.personal.kopmorning.domain.football.responseCode.FootBallSuccessCode;
 import com.personal.kopmorning.domain.football.service.FootBallService;
 import com.personal.kopmorning.global.entity.RsData;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/football")
 @RequiredArgsConstructor
@@ -29,6 +31,8 @@ public class FootBallController {
         footBallService.saveStanding();
         footBallService.saveFixtures();
         footBallService.saveTopScorer();
+
+        log.info("✅ Write-Around 방식: DB만 저장");
         return new RsData<>(
                 FootBallSuccessCode.SAVE_INFO.getCode(),
                 FootBallSuccessCode.SAVE_INFO.getMessage()

--- a/backend/src/main/java/com/personal/kopmorning/domain/football/dto/response/RankingResponse.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/football/dto/response/RankingResponse.java
@@ -3,11 +3,13 @@ package com.personal.kopmorning.domain.football.dto.response;
 import com.personal.kopmorning.domain.football.entity.Player;
 import com.personal.kopmorning.domain.football.entity.Ranking;
 import com.personal.kopmorning.domain.football.entity.Team;
+import lombok.AllArgsConstructor;
 import lombok.Data;
-
-import java.util.Optional;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class RankingResponse {
     private int rank;
     private Long goals;

--- a/backend/src/main/java/com/personal/kopmorning/domain/football/dto/response/StandingResponse.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/football/dto/response/StandingResponse.java
@@ -3,11 +3,13 @@ package com.personal.kopmorning.domain.football.dto.response;
 import com.personal.kopmorning.domain.football.entity.Standing;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class StandingResponse {
     List<Standing> standings;
 }

--- a/backend/src/main/java/com/personal/kopmorning/domain/football/responseCode/FootBallErrorCode.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/football/responseCode/FootBallErrorCode.java
@@ -8,6 +8,7 @@ public enum FootBallErrorCode {
 
     TEAM_NOT_FOUND("404", "해당 팀이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     PLAYER_NOT_FOUND("404", "해당 선수가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    RANKING_NOT_FOUND("404", "랭킹 불러오기 실패", HttpStatus.NOT_FOUND),
     TEAM_API_ERROR("500", "팀 정보를 불러오는 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     STANDING_API_ERROR("500", "순위 정보를 불러오는 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     PLAYER_API_ERROR("500", "선수 정보를 저장하는 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/backend/src/main/java/com/personal/kopmorning/domain/football/responseCode/FootBallSuccessCode.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/football/responseCode/FootBallSuccessCode.java
@@ -9,7 +9,9 @@ public enum FootBallSuccessCode {
     GET_TEAM_LIST("200-3", "팀 목록 가져오기 성공"),
     GET_TEAM_ONE("200-4", "팀 세부 사항 조회 성공"),
     GET_PLAYER_INFO("200-5", "선수 상세 정보 조회 성공"),
-    GET_STANDING("200-6", "순위표 조회 성공");
+    GET_STANDING("200-6", "순위표 조회 성공"),
+    GET_GAME_LIST("200-7", "경기 목록 조회 성공"),
+    GET_RANKING_LIST("200-8", "랭킹 목록 조회 성공");
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/personal/kopmorning/domain/football/service/FootBallService.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/football/service/FootBallService.java
@@ -152,11 +152,8 @@ public class FootBallService {
         }
     }
 
-    public void fallbackOpenAPI(Throwable t) {
-        log.error("🛑 Fallback 호출 - saveStanding() 실패", t);
-        // 알림, 큐 저장 등 필요 조치
-    }
-
+    @Retry(name = "footballApi", fallbackMethod = "fallbackOpenAPI")
+    @CircuitBreaker(name = "footballApi", fallbackMethod = "fallbackOpenAPI")
     public void saveFixtures() {
         try {
             MatchDTO matchDTO = webClient.get()
@@ -209,6 +206,10 @@ public class FootBallService {
                     FootBallErrorCode.TOP_SCORER_API_ERROR.getHttpStatus()
             );
         }
+    }
+
+    public void fallbackOpenAPI(Throwable t) {
+        log.error("🛑 Fallback 호출 - saveStanding() 실패", t);
     }
 
     public List<TeamResponse> getTeams() {

--- a/backend/src/main/java/com/personal/kopmorning/domain/football/service/FootBallService.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/football/service/FootBallService.java
@@ -28,6 +28,7 @@ import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -237,7 +238,9 @@ public class FootBallService {
         return new TeamDetailResponse(team, players);
     }
 
+    @Cacheable(value = "standingCache", key = "'standing'")
     public StandingResponse getStanding() {
+        log.info("⛔ 캐시에 없음 → DB 조회 → 캐시에 저장");
         List<Standing> standing = standingRepository.findAllByOrderByPositionDesc();
         return new StandingResponse(standing);
     }
@@ -247,7 +250,9 @@ public class FootBallService {
         return gameList.stream().map(GameResponse::new).toList();
     }
 
+    @Cacheable(value = "rankingCache", key = "'ranking:' + #standard")
     public List<RankingResponse> getRanking(String standard) {
+        log.info("⛔ 캐시에 없음 → DB 조회 → 캐시에 저장");
         List<Ranking> ranking;
 
         if (standard.equals(GOALS_PARAM)) {

--- a/backend/src/main/java/com/personal/kopmorning/domain/football/service/FootBallService.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/football/service/FootBallService.java
@@ -24,6 +24,8 @@ import com.personal.kopmorning.domain.football.repository.StandingRepository;
 import com.personal.kopmorning.domain.football.repository.TeamRepository;
 import com.personal.kopmorning.domain.football.responseCode.FootBallErrorCode;
 import com.personal.kopmorning.global.exception.FootBall.FootBallException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.ParameterizedTypeReference;
@@ -32,10 +34,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -48,6 +48,14 @@ public class FootBallService {
     private final PlayerRepository playerRepository;
     private final RankingRepository rankingRepository;
     private final StandingRepository standingRepository;
+
+    private static final String GOALS_PARAM = "goals";
+    private static final String OVERALL_PARAM = "overall";
+
+    private static final String GAME_REQUEST_PATH = "teams/64/matches";
+    private static final String TEAMS_REQUEST_PATH = "competitions/PL/teams";
+    private static final String RANKING_REQUEST_PATH = "competitions/PL/scorers";
+    private static final String STANDING_REQUEST_PATH = "competitions/PL/standings";
 
 
     public FootBallService(
@@ -69,14 +77,16 @@ public class FootBallService {
 
 
     // todo : 대회 정보, 팀 별 국가 데이터
-    public void saveFootBallData() {
+    @Retry(name = "footballApi", fallbackMethod = "fallbackOpenAPI")
+    @CircuitBreaker(name = "footballApi", fallbackMethod = "fallbackOpenAPI")
+    public void saveTeamAndPlayer() {
         try {
             List<Player> playerList = new ArrayList<>();
             List<Coach> coachList = new ArrayList<>();
 
             TeamDTO teamDTO = webClient.get()
                     .uri(uriBuilder -> uriBuilder
-                            .path("competitions/PL/teams")
+                            .path(TEAMS_REQUEST_PATH)
                             .build())
                     .retrieve()
                     .bodyToMono(new ParameterizedTypeReference<TeamDTO>() {
@@ -110,11 +120,14 @@ public class FootBallService {
         }
     }
 
+
+    @Retry(name = "footballApi", fallbackMethod = "fallbackOpenAPI")
+    @CircuitBreaker(name = "footballApi", fallbackMethod = "fallbackOpenAPI")
     public void saveStanding() {
         try {
             StandingDTO standingDTO = webClient.get()
                     .uri(uriBuilder -> uriBuilder
-                            .path("competitions/PL/standings")
+                            .path(STANDING_REQUEST_PATH)
                             .build())
                     .retrieve()
                     .bodyToMono(new ParameterizedTypeReference<StandingDTO>() {
@@ -139,11 +152,16 @@ public class FootBallService {
         }
     }
 
+    public void fallbackOpenAPI(Throwable t) {
+        log.error("🛑 Fallback 호출 - saveStanding() 실패", t);
+        // 알림, 큐 저장 등 필요 조치
+    }
+
     public void saveFixtures() {
         try {
             MatchDTO matchDTO = webClient.get()
                     .uri(uriBuilder -> uriBuilder
-                            .path("teams/64/matches")
+                            .path(GAME_REQUEST_PATH)
                             .build())
                     .retrieve()
                     .bodyToMono(new ParameterizedTypeReference<MatchDTO>() {})
@@ -165,11 +183,13 @@ public class FootBallService {
         }
     }
 
+    @Retry(name = "footballApi", fallbackMethod = "fallbackOpenAPI")
+    @CircuitBreaker(name = "footballApi", fallbackMethod = "fallbackOpenAPI")
     public void saveTopScorer() {
         try {
             RankingDTO rankingDTO = webClient.get()
                     .uri(uriBuilder -> uriBuilder
-                            .path("competitions/PL/scorers")
+                            .path(RANKING_REQUEST_PATH)
                             .build())
                     .retrieve()
                     .bodyToMono(new ParameterizedTypeReference<RankingDTO>() {})
@@ -229,12 +249,16 @@ public class FootBallService {
     public List<RankingResponse> getRanking(String standard) {
         List<Ranking> ranking;
 
-        if (standard.equals("goals")) {
+        if (standard.equals(GOALS_PARAM)) {
             ranking = rankingRepository.findAllByOrderByGoalsDesc();
-        } else if (standard.equals("overall")) {
+        } else if (standard.equals(OVERALL_PARAM)) {
             ranking = rankingRepository.findAllOrderByGoalPlusAssistNative();
         } else {
-            throw new IllegalArgumentException("Invalid standard");
+            throw new FootBallException(
+                    FootBallErrorCode.RANKING_NOT_FOUND.getCode(),
+                    FootBallErrorCode.RANKING_NOT_FOUND.getMessage(),
+                    FootBallErrorCode.RANKING_NOT_FOUND.getHttpStatus()
+            );
         }
 
         AtomicInteger rankCounter = new AtomicInteger(1);

--- a/backend/src/main/java/com/personal/kopmorning/global/config/CacheConfig.java
+++ b/backend/src/main/java/com/personal/kopmorning/global/config/CacheConfig.java
@@ -1,0 +1,36 @@
+package com.personal.kopmorning.global.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+    @Bean
+    public RedisCacheConfiguration redisCacheConfiguration() {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new GenericJackson2JsonRedisSerializer()
+                        )
+                )
+                .entryTtl(Duration.ofMinutes(30))
+                .disableCachingNullValues();
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/personal/kopmorning/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/personal/kopmorning/global/config/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.personal.kopmorning.global.redis;
+package com.personal.kopmorning.global.config;
 
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
@@ -10,7 +10,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -32,15 +32,18 @@ public class RedisConfig {
 
     // 직렬화 설정
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
 
-        template.setConnectionFactory(redisConnectionFactory());
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
 
-        // 직렬화 설정
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new GenericToStringSerializer<>(Object.class));
+        template.setValueSerializer(serializer);
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
 
+        template.afterPropertiesSet();
         return template;
     }
 

--- a/backend/src/main/java/com/personal/kopmorning/global/init/BaseInitData.java
+++ b/backend/src/main/java/com/personal/kopmorning/global/init/BaseInitData.java
@@ -3,6 +3,9 @@ package com.personal.kopmorning.global.init;
 import com.personal.kopmorning.domain.article.article.entity.Article;
 import com.personal.kopmorning.domain.article.article.entity.Category;
 import com.personal.kopmorning.domain.article.article.repository.ArticleRepository;
+import com.personal.kopmorning.domain.football.entity.Ranking;
+import com.personal.kopmorning.domain.football.repository.PlayerRepository;
+import com.personal.kopmorning.domain.football.repository.RankingRepository;
 import com.personal.kopmorning.domain.member.entity.Member;
 import com.personal.kopmorning.domain.member.entity.Member_Status;
 import com.personal.kopmorning.domain.member.entity.Role;
@@ -12,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -19,16 +23,18 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@Profile("local")
 public class BaseInitData implements ApplicationRunner {
 
     private final MemberRepository memberRepository;
+    private final RankingRepository rankingRepository;
     private final ArticleRepository articleRepository;
-    private final TokenService tokenService;
 
     @Override
     public void run(ApplicationArguments args) {
         memberInit();
         articleInit();
+        playerInit();
     }
 
     private void memberInit() {
@@ -134,5 +140,18 @@ public class BaseInitData implements ApplicationRunner {
                 .category(Category.FOOTBALL)
                 .member(members.get(4))
                 .build());
+    }
+
+    private void playerInit() {
+        List<Ranking> rankings = List.of(
+                new Ranking(null, 12L, 7L, 2L, 16347L, 64L),     // Dominik Szoboszlai
+                new Ranking(null, 10L, 15L, 1L, 19334L, 64L),    // Florian Wirtz
+                new Ranking(null, 9L, 5L, 0L, 22396L, 64L),      // Luis Díaz
+                new Ranking(null, 18L, 6L, 3L, 28612L, 64L),     // Darwin Núñez
+                new Ranking(null, 6L, 10L, 2L, 45681L, 64L),     // Alexis Mac Allister
+                new Ranking(null, 4L, 8L, 0L, 81793L, 64L)       // Ryan Gravenberch
+        );
+
+        rankingRepository.saveAll(rankings);
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,4 +41,24 @@ logging:
   level:
     org.springframework.web.reactive.function.client.ExchangeFunctions: DEBUG
 
+resilience4j:
+  circuitbreaker:
+    instances:
+      kopMorning:
+        register-health-indicator: true
+        sliding-window-size: 10         # 최근 10개의 호출 기준
+        failure-rate-threshold: 50      # 실패율 50% 넘어가면 Open
+        wait-duration-in-open-state: 5s # Open 상태 유지 시간
+        permitted-number-of-calls-in-half-open-state: 3
+        sliding-window-type: COUNT_BASED
+  retry:
+    instances:
+      kopMorning:
+        max-attempts: 3     # 최대 시도 횟수 (최초 포함 3번)
+        wait-duration: 2s   # 재시도 간 대기 시간
+        retry-exceptions:
+          - java.io.IOException
+          - java.util.concurrent.TimeoutException
+
+
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -14,6 +14,8 @@ spring:
               - profile
               - email
   data:
+    cache:
+      type: redis
     redis:
       host: ${REDIS.HOST}
       port: ${REDIS.PORT}


### PR DESCRIPTION
# 📋 Pull Request Template

## 📌 개요 (Description)
- 작업 내용을 간략하게 설명하세요.
1. 서킷 브레이커 구현
 - Open API 에러 발생 시 회복, 고가용성 개선
2. Redis 캐시 전략 구성
 - Look aside + Write Around 전략 사용
 - 캐시 스토어 ( Redis ) 에 리그 순위, 득점 랭킹 등 정보를 캐싱하여 자주 조회되는 데이터 응답 속도 개선
3. Redis 직렬화/역직렬화 설정
---

## 🛠️ 작업 내용 (Changes)
- [] 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [x] 문서 수정

---

## 🔗 관련 이슈 (Related Issues)
- 관련 이슈: #이슈번호
#18 
---

## 📸 스크린샷 (선택)
- 결과 화면이나 주요 기능 작동 결과를 첨부하세요.
- 캐싱 이전 응답 속도
![redis 캐싱 적용 - 캐싱 이전](https://github.com/user-attachments/assets/0972b12e-c946-4d13-85dd-283e07511a66)

- 캐싱 이후 응답 속도
![redis 캐싱 적용 - 캐싱 이후](https://github.com/user-attachments/assets/e817aaae-fe34-4fba-ac5a-0a01acfb817c)
