### PR TITLE
test: webclient 비동기로 작동하게 수정 및 속도 측정

### DIFF
--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -13,3 +13,4 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+        generate_statistics: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -76,6 +76,10 @@ api:
 logging:
   level:
     org.springframework.web.reactive.function.client.ExchangeFunctions: DEBUG
+    reactor.netty.http.client: DEBUG
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace
+
 
 resilience4j:
   circuitbreaker:


### PR DESCRIPTION
# 📋 Pull Request Template

## 📌 개요 (Description)
- 작업 내용을 간략하게 설명하세요.
1. webclient 동기로 수행되고 있었습니다. 
2. 비동기로 작동하게 수정
3. 동기, 비동기 응답 속도 테스트
---

## 🛠️ 작업 내용 (Changes)
- [x] 버그 수정
- [x] 코드 리팩토링
- [x] 문서 수정

---

## 🔗 관련 이슈 (Related Issues)
- 관련 이슈: #이슈번호
#35 
---

## 🚀 테스트 방법 (How to Test)
1. [x] 테스트 환경 설정
4. [x] 테스트 실행 방법 설명

---

## 📸 스크린샷 (선택)
<img width="1108" height="53" alt="webclient-비동기처리(스케줄러임)" src="https://github.com/user-attachments/assets/617cd18e-fd72-4597-b36e-6eccd569f6d5" />
-> webclient 비동기
<img width="1275" height="178" alt="resttmplate-completableFuture를 통한 비동기" src="https://github.com/user-attachments/assets/f636c6a4-286a-4d36-af1d-9736bf55dbdc" />
->  restTemplate를 completableFuture로 이용한 비동기 처리

->응답 속도는 비슷하지만, restTemplate는 블로킹 i/o 방식이기 때문에 스레드가 낭비되는 현상 발생
