### PR TITLE
refactor: JPA N+1 문제 해결

### DIFF
--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run Gradle Build
         working-directory: backend
-        run: ./gradlew build -i
+        run: ./gradlew build
 
       - name: Upload Test Results
         if: always()

--- a/backend/src/main/java/com/personal/kopmorning/domain/admin/service/AdminService.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/admin/service/AdminService.java
@@ -119,7 +119,7 @@ public class AdminService {
 
         Long nextCursor = articleResponses.isEmpty() ? null : articleResponses.getLast().getId();
 
-        return new ArticleListResponse(articleResponses, articleList.size(), category, nextCursor);
+        return new ArticleListResponse(articleResponses, category, nextCursor);
     }
 
     // 회원 정지

--- a/backend/src/main/java/com/personal/kopmorning/domain/article/article/dto/response/ArticleListResponse.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/article/article/dto/response/ArticleListResponse.java
@@ -13,9 +13,9 @@ public class ArticleListResponse {
     private String category;
 
     @Builder
-    public ArticleListResponse(List<ArticleResponse> articles, int total, String category, Long nextCursor) {
+    public ArticleListResponse(List<ArticleResponse> articles, String category, Long nextCursor) {
         this.articles = articles;
-        this.total = total;
+        this.total = articles.size();
         this.nextCursor = nextCursor;
         this.category = category;
     }

--- a/backend/src/main/java/com/personal/kopmorning/domain/article/article/dto/response/ArticleResponse.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/article/article/dto/response/ArticleResponse.java
@@ -29,7 +29,7 @@ public class ArticleResponse {
         this.likeCount = article.getLikeCount();
         this.viewCount = article.getViewCount();
         this.member_id = article.getMember().getId();
-        this.commentCount = (long) article.getComments().size();
+        this.commentCount = article.getComments() != null ? (long) article.getComments().size() : 0L;
 
         this.title = article.getTitle();
         this.body = article.getBody();

--- a/backend/src/main/java/com/personal/kopmorning/domain/article/article/dto/response/ArticleResponse.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/article/article/dto/response/ArticleResponse.java
@@ -11,6 +11,7 @@ public class ArticleResponse {
     private Long likeCount;
     private Long viewCount;
     private Long member_id;
+    private Long commentCount;
 
     private String title;
     private String body;
@@ -28,6 +29,7 @@ public class ArticleResponse {
         this.likeCount = article.getLikeCount();
         this.viewCount = article.getViewCount();
         this.member_id = article.getMember().getId();
+        this.commentCount = (long) article.getComments().size();
 
         this.title = article.getTitle();
         this.body = article.getBody();

--- a/backend/src/main/java/com/personal/kopmorning/domain/article/article/entity/Article.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/article/article/entity/Article.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -47,6 +48,7 @@ public class Article {
     private List<ArticleLike> likes = new ArrayList<>();
 
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 1000)
     private List<ArticleComment> comments = new ArrayList<>();
 
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/backend/src/main/java/com/personal/kopmorning/domain/article/article/entity/Article.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/article/article/entity/Article.java
@@ -4,16 +4,7 @@ import com.personal.kopmorning.domain.article.comment.entity.ArticleComment;
 import com.personal.kopmorning.domain.article.like.entity.ArticleLike;
 import com.personal.kopmorning.domain.member.entity.Member;
 import com.personal.kopmorning.domain.report.entity.Report;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -48,7 +39,7 @@ public class Article {
     @Enumerated(EnumType.STRING)
     private Category category;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn
     private Member member;
 

--- a/backend/src/main/java/com/personal/kopmorning/domain/article/article/repository/ArticleRepository.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/article/article/repository/ArticleRepository.java
@@ -4,29 +4,41 @@ import com.personal.kopmorning.domain.article.article.entity.Article;
 import com.personal.kopmorning.domain.article.article.entity.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
-    // 첫 페이지: 카테고리 없이 최신순
+    // 카테고리 없이 최신순-Member 함께 조회
+    @EntityGraph(attributePaths = {"member"})
     Page<Article> findAll(Pageable pageable);
 
-    // 커서 페이지: 카테고리 없이 최신순
+    // 카테고리 없이 최신순-Member 함께 조회
+    @EntityGraph(attributePaths = {"member"})
     List<Article> findByIdLessThanOrderByIdDesc(Long id, Pageable pageable);
 
-    // 첫 페이지: 카테고리 필터
+    // 카테고리 필터-Member 함께 조회
+    @EntityGraph(attributePaths = {"member"})
     Page<Article> findByCategory(Category category, Pageable pageable);
 
-    // 커서 페이지: 카테고리 필터
+    // 카테고리 필터-Member 함께 조회
+    @EntityGraph(attributePaths = {"member"})
     List<Article> findByCategoryAndIdLessThanOrderByIdDesc(Category category, Long id, Pageable pageable);
 
-    // 검색어 포함
+    // 검색어 포함-전체, 첫 페이지 - Member 함께 조회
+    @EntityGraph(attributePaths = {"member"})
     List<Article> findByTitleContainingIgnoreCaseOrderByIdDesc(String titleKeyword, Pageable pageable);
 
+    // 검색어 포함-전체, 커서 - Member 함께 조회
+    @EntityGraph(attributePaths = {"member"})
     List<Article> findByIdLessThanAndTitleContainingIgnoreCaseOrderByIdDesc(Long cursor, String titleKeyword, Pageable pageable);
 
+    // 검색어 포함-카테고리, 첫 페이지 - Member 함께 조회
+    @EntityGraph(attributePaths = {"member"})
     List<Article> findByCategoryAndTitleContainingIgnoreCaseOrderByIdDesc(Category category, String titleKeyword, Pageable pageable);
 
+    // 검색어 포함-카테고리, 커서 - Member 함께 조회
+    @EntityGraph(attributePaths = {"member"})
     List<Article> findByCategoryAndIdLessThanAndTitleContainingIgnoreCaseOrderByIdDesc(Category category, Long cursor, String titleKeyword, Pageable pageable);
 }

--- a/backend/src/main/java/com/personal/kopmorning/domain/article/comment/repository/ArticleCommentRepository.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/article/comment/repository/ArticleCommentRepository.java
@@ -1,16 +1,19 @@
 package com.personal.kopmorning.domain.article.comment.repository;
 
 import com.personal.kopmorning.domain.article.comment.entity.ArticleComment;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
     // 커서 없는 경우
+    @EntityGraph(attributePaths = {"member"})
     List<ArticleComment> findByArticleIdOrderByIdDesc(Long articleId, Pageable pageable);
+
     // 커서가 존재하는 경우
+    @EntityGraph(attributePaths = {"member"})
     List<ArticleComment> findByArticleIdAndIdLessThanOrderByIdDesc(Long articleId, Long cursor, Pageable pageable);
 
 }

--- a/backend/src/main/java/com/personal/kopmorning/domain/article/like/service/LikeService.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/article/like/service/LikeService.java
@@ -10,10 +10,7 @@ import com.personal.kopmorning.domain.article.like.repository.ArticleLikeReposit
 import com.personal.kopmorning.domain.article.like.repository.CommentLikeRepository;
 import com.personal.kopmorning.domain.article.responseCode.ArticleErrorCode;
 import com.personal.kopmorning.domain.member.entity.Member;
-import com.personal.kopmorning.domain.member.repository.MemberRepository;
-import com.personal.kopmorning.domain.member.responseCode.MemberErrorCode;
 import com.personal.kopmorning.global.exception.Article.ArticleException;
-import com.personal.kopmorning.global.exception.member.MemberException;
 import com.personal.kopmorning.global.utils.SecurityUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class LikeService {
     private final RedissonClient redissonClient;
-    private final MemberRepository memberRepository;
     private final ArticleRepository articleRepository;
     private final ArticleLikeRepository articleLikeRepository;
     private final CommentLikeRepository commentLikeRepository;
@@ -44,12 +40,7 @@ public class LikeService {
 
     @Transactional
     public boolean handleArticleLike(Long articleId) {
-        Member member = memberRepository.findById(SecurityUtil.getRequiredMemberId())
-                .orElseThrow(() -> new MemberException(
-                        MemberErrorCode.MEMBER_NOT_FOUND.getCode(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getMessage(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getHttpStatus()
-                ));
+        Member member = SecurityUtil.getCurrentMember();
 
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new ArticleException(
@@ -94,12 +85,7 @@ public class LikeService {
     }
 
     public boolean handleArticleCommentLike(Long commentId) {
-        Member member = memberRepository.findById(SecurityUtil.getRequiredMemberId())
-                .orElseThrow(() -> new MemberException(
-                        MemberErrorCode.MEMBER_NOT_FOUND.getCode(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getMessage(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getHttpStatus()
-                ));
+        Member member = SecurityUtil.getCurrentMember();
 
         ArticleComment articleComment = articleCommentRepository.findById(commentId)
                 .orElseThrow(() -> new ArticleException(

--- a/backend/src/main/java/com/personal/kopmorning/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/member/controller/MemberController.java
@@ -21,9 +21,6 @@ public class MemberController {
     private final CookieUtil cookieUtil;
     private final MemberService memberService;
 
-    private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String BEARER_PREFIX = "Bearer ";
-
     @GetMapping
     public RsData<MemberResponse> getMember() {
         return new RsData<>(
@@ -66,7 +63,6 @@ public class MemberController {
         );
     }
 
-    // todo : 탈퇴한 유저라면 어떤 식으로 클라이언트에게 표현해야 하는 지 고민해야 할 필요가 있음.
     @PatchMapping("/delete/cancel")
     public RsData<?> deleteCancel() {
         memberService.deleteCancel();

--- a/backend/src/main/java/com/personal/kopmorning/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/member/entity/Member.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 

--- a/backend/src/main/java/com/personal/kopmorning/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/member/service/MemberService.java
@@ -23,23 +23,13 @@ public class MemberService {
 
     // 회원 정보 수정 메서드
     @Transactional
-    // TODO: 멤버 가져오는 방식 리펙토링 해야할 듯 - getMemberBySecurityMember() 메서드 이용해서
     public void update(MemberProfileUpdate request) {
-        Member member = memberRepository.findById(SecurityUtil.getRequiredMemberId())
-                .orElseThrow(() -> new MemberException(
-                        MemberErrorCode.MEMBER_NOT_FOUND.getCode(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getMessage(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getHttpStatus()
-                ));
+        Member member = SecurityUtil.getCurrentMember();
 
         if (member != null) {
             member.setNickname(request.getNickname());
             member.setUpdated_at(LocalDateTime.now());
         }
-    }
-
-    public Member getMemberBySecurityMember() {
-        return SecurityUtil.getCurrentMember();
     }
 
     public void logout(String accessToken, String refreshToken) {
@@ -49,40 +39,27 @@ public class MemberService {
     }
 
     // 회원탈퇴 신청
-    // TODO: 멤버 가져오는 방식 리펙토링 해야할 듯 - getMemberBySecurityMember() 메서드 이용해서
     @Transactional
     public void deleteRequest() {
-        Member member = memberRepository.findById(SecurityUtil.getRequiredMemberId())
-                .orElseThrow(() -> new MemberException(
-                        MemberErrorCode.MEMBER_NOT_FOUND.getCode(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getMessage(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getHttpStatus()
-                ));
+        Member member = SecurityUtil.getCurrentMember();
 
         member.withdraw();
     }
 
     // 회원탈퇴 철회
-    // TODO: 멤버 가져오는 방식 리펙토링 해야할 듯 - getMemberBySecurityMember() 메서드 이용해서
     @Transactional
     public void deleteCancel() {
-        Member member = memberRepository.findById(SecurityUtil.getRequiredMemberId())
-                .orElseThrow(() -> new MemberException(
-                        MemberErrorCode.MEMBER_NOT_FOUND.getCode(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getMessage(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getHttpStatus()
-                ));
+        Member member = SecurityUtil.getCurrentMember();
         member.isActive();
     }
 
     // 즉시 회원탈퇴
     public void deleteImmediately() {
-        Member member = memberRepository.findById(SecurityUtil.getRequiredMemberId())
-                .orElseThrow(() -> new MemberException(
-                        MemberErrorCode.MEMBER_NOT_FOUND.getCode(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getMessage(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getHttpStatus()
-                ));
+        Member member = SecurityUtil.getCurrentMember();
         memberRepository.deleteById(member.getId());
+    }
+
+    public Member getMemberBySecurityMember() {
+        return SecurityUtil.getCurrentMember();
     }
 }

--- a/backend/src/main/java/com/personal/kopmorning/domain/report/service/ReportService.java
+++ b/backend/src/main/java/com/personal/kopmorning/domain/report/service/ReportService.java
@@ -6,15 +6,12 @@ import com.personal.kopmorning.domain.article.comment.entity.ArticleComment;
 import com.personal.kopmorning.domain.article.comment.repository.ArticleCommentRepository;
 import com.personal.kopmorning.domain.article.responseCode.ArticleErrorCode;
 import com.personal.kopmorning.domain.member.entity.Member;
-import com.personal.kopmorning.domain.member.repository.MemberRepository;
-import com.personal.kopmorning.domain.member.responseCode.MemberErrorCode;
 import com.personal.kopmorning.domain.report.dto.request.ReportRequest;
 import com.personal.kopmorning.domain.report.dto.response.ReportListResponse;
 import com.personal.kopmorning.domain.report.dto.response.ReportResponse;
 import com.personal.kopmorning.domain.report.entity.Report;
 import com.personal.kopmorning.domain.report.repository.ReportRepository;
 import com.personal.kopmorning.global.exception.Article.ArticleException;
-import com.personal.kopmorning.global.exception.member.MemberException;
 import com.personal.kopmorning.global.utils.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -28,17 +25,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ReportService {
     private final ReportRepository reportRepository;
-    private final MemberRepository memberRepository;
     private final ArticleRepository articleRepository;
     private final ArticleCommentRepository articleCommentRepository;
 
     public void article(ReportRequest request) {
-        Member member = memberRepository.findById(SecurityUtil.getRequiredMemberId())
-                .orElseThrow(() -> new MemberException(
-                        MemberErrorCode.MEMBER_NOT_FOUND.getCode(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getMessage(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getHttpStatus()
-                ));
+        Member member = SecurityUtil.getCurrentMember();
 
         Article article = articleRepository.findById(request.getId())
                 .orElseThrow(() -> new ArticleException(
@@ -54,12 +45,7 @@ public class ReportService {
 
 
     public void comment(ReportRequest request) {
-        Member member = memberRepository.findById(SecurityUtil.getRequiredMemberId())
-                .orElseThrow(() -> new MemberException(
-                        MemberErrorCode.MEMBER_NOT_FOUND.getCode(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getMessage(),
-                        MemberErrorCode.MEMBER_NOT_FOUND.getHttpStatus()
-                ));
+        Member member = SecurityUtil.getCurrentMember();
 
         ArticleComment comment = articleCommentRepository.findById(request.getId())
                 .orElseThrow(() -> new ArticleException(

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -14,3 +14,4 @@ spring:
         highlight_sql: true
         use_sql_comments: true
         generate_statistics: true
+        default_batch_fetch_size: 100

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -14,4 +14,4 @@ spring:
         highlight_sql: true
         use_sql_comments: true
         generate_statistics: true
-        default_batch_fetch_size: 100
+#        default_batch_fetch_size: 100

--- a/backend/src/test/java/com/personal/kopmorning/Article/service/LikeServiceTest.java
+++ b/backend/src/test/java/com/personal/kopmorning/Article/service/LikeServiceTest.java
@@ -24,6 +24,7 @@ import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -77,6 +78,9 @@ class LikeServiceTest {
                 .updatedAt(LocalDateTime.now())
                 .likeCount(0L)
                 .viewCount(0L)
+                .comments(new ArrayList<>())
+                .likes(new ArrayList<>())
+                .reports(new ArrayList<>())
                 .build();
     }
 
@@ -88,9 +92,8 @@ class LikeServiceTest {
         @DisplayName("좋아요 추가 성공")
         void addLike_success() throws InterruptedException {
             try (MockedStatic<SecurityUtil> util = mockStatic(SecurityUtil.class)) {
-                util.when(SecurityUtil::getRequiredMemberId).thenReturn(1L);
+                util.when(SecurityUtil::getCurrentMember).thenReturn(stubMember);
 
-                when(memberRepository.findById(1L)).thenReturn(Optional.of(stubMember));
                 when(articleRepository.findById(10L)).thenReturn(Optional.of(stubArticle));
 
                 when(redissonClient.getLock(anyString())).thenReturn(lock);
@@ -116,10 +119,9 @@ class LikeServiceTest {
             stubArticle.increaseLikeCount(); // 초기 좋아요 수 = 1
 
             try (MockedStatic<SecurityUtil> util = mockStatic(SecurityUtil.class)) {
-                util.when(SecurityUtil::getRequiredMemberId).thenReturn(1L);
+                util.when(SecurityUtil::getCurrentMember).thenReturn(stubMember);
 
                 // given
-                when(memberRepository.findById(1L)).thenReturn(Optional.of(stubMember));
                 when(articleRepository.findById(10L)).thenReturn(Optional.of(stubArticle));
                 when(redissonClient.getLock(anyString())).thenReturn(lock);
                 when(lock.tryLock(anyLong(), anyLong(), any())).thenReturn(true);

--- a/backend/src/test/java/com/personal/kopmorning/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/personal/kopmorning/member/service/MemberServiceTest.java
@@ -6,21 +6,18 @@ import com.personal.kopmorning.domain.member.entity.MemberStatus;
 import com.personal.kopmorning.domain.member.entity.Role;
 import com.personal.kopmorning.domain.member.repository.MemberRepository;
 import com.personal.kopmorning.domain.member.service.MemberService;
-import com.personal.kopmorning.global.security.PrincipalDetails;
+import com.personal.kopmorning.global.utils.SecurityUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mockStatic;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -38,14 +35,6 @@ class MemberServiceTest {
         member.setRole(Role.USER);
         member.setId(1L);
         member.setNickname("테스트 유저");
-
-        PrincipalDetails principalDetails = new PrincipalDetails(member);
-        UsernamePasswordAuthenticationToken authentication =
-                new UsernamePasswordAuthenticationToken(principalDetails, null, principalDetails.getAuthorities());
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
     }
 
     @Test
@@ -55,23 +44,31 @@ class MemberServiceTest {
         MemberProfileUpdate dto = new MemberProfileUpdate();
         dto.setNickname("테스트 멤버");
 
-        // when
-        memberService.update(dto);
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentMember).thenReturn(member);
 
-        // then
-        assertThat(member.getNickname()).isEqualTo("테스트 멤버");
-        assertThat(member.getUpdated_at()).isNotNull();
+            // when
+            memberService.update(dto);
+
+            // then
+            assertThat(member.getNickname()).isEqualTo("테스트 멤버");
+            assertThat(member.getUpdated_at()).isNotNull();
+        }
     }
 
     @Test
     @DisplayName("회원 탈퇴 신청에 성공한다.")
     void requestMemberDeletion_success() {
-        // when
-        memberService.deleteRequest();
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentMember).thenReturn(member);
 
-        // then
-        assertThat(member.getStatus()).isEqualTo(MemberStatus.DELETED);
-        assertThat(member.getDeleteAt()).isNotNull();
+            // when
+            memberService.deleteRequest();
+
+            // then
+            assertThat(member.getStatus()).isEqualTo(MemberStatus.DELETED);
+            assertThat(member.getDeleteAt()).isNotNull();
+        }
     }
 
     @Test
@@ -80,11 +77,15 @@ class MemberServiceTest {
         // given
         member.withdraw(); // 탈퇴 상태로 변경
 
-        // when
-        memberService.deleteCancel();
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentMember).thenReturn(member);
 
-        // then
-        assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
-        assertThat(member.getDeleteAt()).isNull();
+            // when
+            memberService.deleteCancel();
+
+            // then
+            assertThat(member.getStatus()).isEqualTo(MemberStatus.ACTIVE);
+            assertThat(member.getDeleteAt()).isNull();
+        }
     }
 }

--- a/frontend/src/app/article/[category]/page.tsx
+++ b/frontend/src/app/article/[category]/page.tsx
@@ -21,6 +21,7 @@ type ArticleResponse = {
   likeCount: number;
   viewCount: number;
   member_id: number;
+  commentCount: number;
   title: string;
   category: string;
   memberName: string;
@@ -239,7 +240,7 @@ export default function ArticleCategoryPage({ params }: PageProps) {
             )}
           </div>
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: 16 }}>
-            {articles.map(({ id, title, createdAt, memberName, memberNickname }) => (
+            {articles.map(({ id, title, createdAt, memberName, memberNickname, likeCount, viewCount, commentCount }) => (
               <Link key={id} href={`/article/${category}/${id}`} style={{ textDecoration: "none", color: "inherit" }}>
                 <article
                   style={{
@@ -260,12 +261,26 @@ export default function ArticleCategoryPage({ params }: PageProps) {
                   />
                   <div style={{ padding: 14, display: "grid", gap: 8 }}>
                     <h3 style={{ margin: 0, fontSize: 18, color: "var(--color-text)" }}>{title}</h3>
-                    <div style={{ marginTop: 6, fontSize: 12, color: "var(--color-text-muted)", display: "flex", alignItems: "center", gap: 8 }}>
+                    <div style={{ marginTop: 6, fontSize: 12, color: "var(--color-text-muted)", display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
                       <span style={{ marginLeft: 8, fontWeight: 600, color: "var(--color-primary)" }}>
                         작성자 : {memberNickname || memberName}
                       </span>
                       <span style={{ width: 6, height: 6, borderRadius: 999, background: "var(--color-primary)" }} />
                       {new Date(createdAt).toLocaleDateString()}
+                    </div>
+                    <div style={{ display: "flex", alignItems: "center", gap: 12, fontSize: 12, color: "var(--color-text-muted)", marginTop: 4 }}>
+                      <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                        <span>❤️</span>
+                        <span>{likeCount || 0}</span>
+                      </span>
+                      <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                        <span>💬</span>
+                        <span>{commentCount || 0}</span>
+                      </span>
+                      <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                        <span>👁️</span>
+                        <span>{viewCount || 0}</span>
+                      </span>
                     </div>
                   </div>
                 </article>


### PR DESCRIPTION
# 📋 Pull Request Template

## 📌 개요 (Description)
- 작업 내용을 간략하게 설명하세요.
1. 게시물 조회 시 쿼리가 22개가 발생하는 N+1 문제가 발생
2. 해결하기 위해 쿼리 메소드에 EntityGraph를 통해 outer join로 객체를 한번에 호출하는 쿼리 22 -> 12개로 감소
3. 게시물 댓글 갯수 조회를 위한 쿼리 때문에 10개가 추가로 발생
4. 해결하기 위해 Article (1) : Comment(N) 의 경우 BatchSize를 지정하여 IN 명령어로 댓글을 묶어서 조회 12 -> 2개로 감소
---

## 🛠️ 작업 내용 (Changes)
- [x] 버그 수정
- [x] 코드 리팩토링
- [x] 문서 수정

---

## 🔗 관련 이슈 (Related Issues)
- 관련 이슈: #이슈번호
#37 
---

## 🚀 테스트 방법 (How to Test)
1. [x] 테스트 환경 설정
5. [x] 테스트 실행 방법 설명

---